### PR TITLE
Bumps version number.

### DIFF
--- a/Shivers Randomizer/Properties/AssemblyInfo.cs
+++ b/Shivers Randomizer/Properties/AssemblyInfo.cs
@@ -49,5 +49,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyInformationalVersion("2.5.1")]


### PR DESCRIPTION
Turns out file version and informational version are used in the file details when you examine the properties.