### PR TITLE
Adjust the spacing sizing and resizing

### DIFF
--- a/Shivers Randomizer/Archipelago_Client.xaml
+++ b/Shivers Randomizer/Archipelago_Client.xaml
@@ -1,76 +1,86 @@
-﻿<Window x:Class="Shivers_Randomizer.Archipelago_Client"
+<Window x:Class="Shivers_Randomizer.Archipelago_Client"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:Shivers_Randomizer"
       mc:Ignorable="d" 
-      Height="550" Width="1321" Background="#FF333333" 
+      Height="537" Width="922" Background="#FF333333" MinHeight="537" MinWidth="620"
       Title="Archipelago Client"
       Closing="Window_Closing">
 
     <Grid>
-        <Label Content="Server IP:" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Margin="0,0,0,0" Name="label1" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <TextBox x:Name="serverIP" Text="archipelago.gg:" FontSize="16" Background="#FFF0F0F0" Height="24" Width="206" Margin="80,7,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="467*"/>
+            <RowDefinition Height="30"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1061*"/>
+            <ColumnDefinition Width="305"/>
+        </Grid.ColumnDefinitions>
+
+        <Label Content="Server IP:Port" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Name="label1" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="75" Grid.Row="0" Grid.ColumnSpan="2"/>
+        <TextBox x:Name="serverIP" Text="archipelago.gg:" FontSize="16" Background="#FFF0F0F0" Height="24" Width="206" Margin="80,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Row="0" Grid.ColumnSpan="2"/>
+        <Label Content="Slot:" FontSize="16" Foreground="White" Height="30" HorizontalAlignment="Left" Margin="301,0,0,0" Name="label3" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="41" Grid.ColumnSpan="2"/>
+        <TextBox x:Name="slotName" Text="" FontSize="16" Background="#FFF0F0F0" Height="24" Width="145" Margin="347,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Row="0" Grid.ColumnSpan="2"/>
         <!-- 
-        <Label Content="Port:" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Margin="182,0,0,0" Name="label2" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <TextBox x:Name="serverPort" Text="38281" FontSize="16" Background="#FFF0F0F0" Height="24" Width="67" Margin="229,7,0,0" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+        <Label Content="Password" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Margin="182,0,0,0" Name="label2" VerticalAlignment="Top" VerticalContentAlignment="Center" Grid.Row="0" Grid.ColumnSpan="2"/>
+        <TextBox x:Name="serverPassword" Text="38281" FontSize="16" Background="#FFF0F0F0" Height="24" Width="67" Margin="229,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="0" Grid.ColumnSpan="2"/>
         -->
-        <Label Content="Slot:" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Margin="301,0,0,0" Name="label3" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <TextBox x:Name="slotName" Text="" FontSize="16" Background="#FFF0F0F0" Height="24" Width="145" Margin="347,7,0,0" HorizontalAlignment="Left" VerticalAlignment="Top"/>
-        <Button x:Name="buttonConnect" Content="Connect" FontSize="16" Foreground="White" Background="#FF585858" Height="24" Width="92" Margin="509,7,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Click="buttonConnect_Click" Padding="0,0"/>
-        <TextBox x:Name="ServerMessageBox" Background="#FF333333" FontSize="16" Foreground="White" IsReadOnly="True" Margin="0,38,382,30" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" TextChanged="ServerMessageBox_TextChanged" ScrollViewer.ScrollChanged="ServerMessageBox_ScrollChanged" />
-        <Label Content="Command:" FontSize="16" Foreground="White" Height="30" Width="100" HorizontalAlignment="Left" VerticalAlignment="Bottom" Background="#FF585858" Margin="0,0,0,0"/>
-        <TextBox x:Name="commandBox" FontSize="16" Background="#FFF0F0F0" VerticalContentAlignment="Center" Height="30" Margin="100,0,382,0" TextWrapping="Wrap" VerticalAlignment="Bottom"/>
+        <Button x:Name="buttonConnect" Content="Connect" FontSize="16" Foreground="White" Background="#FF585858" Height="24" Width="92" Margin="509,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Click="buttonConnect_Click" Padding="0,0" Grid.ColumnSpan="2"/>
 
+        <TextBox x:Name="ServerMessageBox" Background="#FF333333" FontSize="16" Foreground="White" IsReadOnly="True" Margin="0,0,0,0" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" TextChanged="ServerMessageBox_TextChanged" ScrollViewer.ScrollChanged="ServerMessageBox_ScrollChanged" Grid.Row="1" />
 
-        <Label Content="Desk Drawer: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,28,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Workshop Drawers: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,48,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Library Cabinet: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,68,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Library Statue: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,88,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Slide: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,108,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Eagles Head: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,128,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Eagles Nest: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,148,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Ocean: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,168,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Tar River: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,188,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Theater: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,208,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Greenhouse: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,228,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Egypt: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,247,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Chinese Solitaire: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,268,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Tiki Hut: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,288,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Lyre: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,308,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Skeleton: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,328,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Anansi: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,348,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Janitor Closet: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,368,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="UFO: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,388,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Alchemy: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,408,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Skull Bridge: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,428,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Hanging: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,448,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="Clock Tower: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="944,468,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
+        <Button x:Name="buttonCommands" Content="Command:" FontSize="16" Foreground="White" Height="28" Width="100" HorizontalAlignment="Left" VerticalAlignment="Center" VerticalContentAlignment="Center" Background="#FF585858" Grid.Row="2"/>
+        <TextBox x:Name="commandBox" FontSize="16" Background="#FFF0F0F0" VerticalContentAlignment="Center" Height="30" Margin="100,0,0,0" TextWrapping="Wrap" VerticalAlignment="Center" Grid.Row="2"/>
 
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1045,28,0,0" Name="LabelStorageDeskDrawer" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1090,48,0,0" Name="LabelStorageWorkshopDrawers" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1062,68,0,0" Name="LabelStorageLibraryCabinet" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1051,88,0,0" Name="LabelStorageLibraryStatue" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="989,108,0,0" Name="LabelStorageSlide" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1042,128,0,0" Name="LabelStorageEaglesHead" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1037,148,0,0" Name="LabelStorageEaglesNest" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1001,168,0,0" Name="LabelStorageOcean" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1015,188,0,0" Name="LabelStorageTarRiver" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1009,208,0,0" Name="LabelStorageTheater" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1040,228,0,0" Name="LabelStorageGreenhouse" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="996,247,0,0" Name="LabelStorageEgypt" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1071,268,0,0" Name="LabelStorageChineseSolitaire" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1009,288,0,0" Name="LabelStorageTikiHut" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="981,308,0,0" Name="LabelStorageLyre" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1015,328,0,0" Name="LabelStorageSkeleton" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1001,348,0,0" Name="LabelStorageAnansi" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1048,368,0,0" Name="LabelStorageJanitorCloset" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="985,388,0,0" Name="LabelStorageUFO" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1014,408,0,0" Name="LabelStorageAlchemy" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1039,428,0,0" Name="LabelStorageSkullBridge" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1015,448,0,0" Name="LabelStorageHanging" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
-        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="1041,468,0,0" Name="LabelStorageClockTower" VerticalAlignment="Top" VerticalContentAlignment="Center"/>
+        <Label Content="Desk Drawer: " FontSize="16" Foreground="#FFA0BE82" Height="31" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="107"/>
+        <Label Content="Workshop Drawers: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,20,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="152"/>
+        <Label Content="Library Cabinet: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,40,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="125"/>
+        <Label Content="Library Statue: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,60,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="115"/>
+        <Label Content="Slide: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,80,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="52"/>
+        <Label Content="Eagle's Head: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,100,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="107"/>
+        <Label Content="Eagle's Nest: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,120,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="103"/>
+        <Label Content="Ocean: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,140,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="63"/>
+        <Label Content="Tar River: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,160,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="78"/>
+        <Label Content="Theater: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,180,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="71"/>
+        <Label Content="Greenhouse: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,200,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="103"/>
+        <Label Content="Egypt: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,220,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="58"/>
+        <Label Content="Chinese Solitaire: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,240,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="135"/>
+        <Label Content="Tiki Hut: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,260,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="72"/>
+        <Label Content="Lyre: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,280,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="47"/>
+        <Label Content="Skeleton: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="79"/>
+        <Label Content="Anansi: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,320,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="65"/>
+        <Label Content="Janitor Closet: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,340,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="113"/>
+        <Label Content="UFO: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,360,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="49"/>
+        <Label Content="Alchemy: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,380,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="79"/>
+        <Label Content="Skull Bridge: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,400,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="102" Grid.RowSpan="2"/>
+        <Label Content="Hanging: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,420,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="78" Grid.RowSpan="2"/>
+        <Label Content="Clock Tower: " FontSize="16" Foreground="#FFA0BE82" Height="32" HorizontalAlignment="Left" Margin="0,440,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Width="103" Grid.RowSpan="2"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="95,0,0,0" Name="LabelStorageDeskDrawer" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="140,20,0,0" Name="LabelStorageWorkshopDrawers" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="113,40,0,0" Name="LabelStorageLibraryCabinet" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="103,60,0,0" Name="LabelStorageLibraryStatue" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="40,80,0,0" Name="LabelStorageSlide" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="93,100,0,0" Name="LabelStorageEaglesHead" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="91,120,0,0" Name="LabelStorageEaglesNest" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="51,140,0,0" Name="LabelStorageOcean" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="66,160,0,0" Name="LabelStorageTarRiver" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="59,180,0,0" Name="LabelStorageTheater" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="91,200,0,0" Name="LabelStorageGreenhouse" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="46,220,0,0" Name="LabelStorageEgypt" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="123,240,0,0" Name="LabelStorageChineseSolitaire" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="60,260,0,0" Name="LabelStorageTikiHut" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="35,280,0,0" Name="LabelStorageLyre" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="67,300,0,0" Name="LabelStorageSkeleton" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="53,320,0,0" Name="LabelStorageAnansi" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="101,340,0,0" Name="LabelStorageJanitorCloset" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="37,360,0,0" Name="LabelStorageUFO" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="67,380,0,0" Name="LabelStorageAlchemy" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="90,400,0,0" Name="LabelStorageSkullBridge" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="66,420,0,0" Name="LabelStorageHanging" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"/>
+        <Label Content="" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="91,440,0,0" Name="LabelStorageClockTower" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1" Grid.RowSpan="2"/>
     </Grid>
 
 </Window>


### PR DESCRIPTION
• Implemented a 2x3 grid and forced all the content to stay in their respective cells.
• Repurposed and prepped the Port Number label and text box to be used as a password field instead, but left it commented out until there's code to support passwords.
• Spaced the code broken up into the cells that content will go in.
• Spelling corrected from "Eagles Head" and "Eagles Nest" to "Eagle's Head" and "Eagle's Nest" in the content of the label boxes.
• Changed "Command:" from a label to a button, unimplemented at this point.
• Greatly reduced the size and set minimum sizes for height and width.
• Removed the code declaring VerticalContentAlignment for all locations and all location storage as it seemed to not have an impact.