### PR TITLE
QoL updates

### DIFF
--- a/Shivers Randomizer/App.config
+++ b/Shivers Randomizer/App.config
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="Shivers_Randomizer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
+    <userSettings>
+        <Shivers_Randomizer.Properties.Settings>
+            <setting name="serverIp" serializeAs="String">
+                <value>archipelago.gg:</value>
+            </setting>
+            <setting name="slotName" serializeAs="String">
+                <value />
+            </setting>
+        </Shivers_Randomizer.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/Shivers Randomizer/App.xaml.cs
+++ b/Shivers Randomizer/App.xaml.cs
@@ -1465,7 +1465,7 @@ public partial class App : Application
             }
 
             // Save amount of items received
-            archipelago_Client?.SaveData("LastReceivedItemValue", archipelagoReceivedItems?.Count ?? 0);
+            archipelago_Client?.SaveData("NumItemsReceived", archipelagoReceivedItems?.Count ?? 0);
 
             // Save skull dials
             archipelago_Client?.SaveData("SkullDialPrehistoric", ReadMemory(836, 1));

--- a/Shivers Randomizer/App.xaml.cs
+++ b/Shivers Randomizer/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Shivers_Randomizer.room_randomizer;
+﻿using Shivers_Randomizer.Properties;
+using Shivers_Randomizer.room_randomizer;
 using Shivers_Randomizer.utils;
 using System;
 using System.Collections.Generic;
@@ -150,6 +151,7 @@ public partial class App : Application
         multiplayer_Client?.Close();
         multiplayer_Client = null;
         appTimer.Stop();
+        Settings.Default.Save();
         Shutdown();
     }
 

--- a/Shivers Randomizer/App.xaml.cs
+++ b/Shivers Randomizer/App.xaml.cs
@@ -1992,11 +1992,11 @@ public partial class App : Application
         if (archipelago_Client != null)
         {
             // Figure out the matching Location
-            for (int i = 0; i < archipelago_Client.storagePlacementsArray.GetLength(0); i++)
+            foreach (var storage in archipelago_Client.storagePlacementsDict)
             {
-                if (archipelago_Client.storagePlacementsArray[i, 1] == pieceName)
+                if (storage.Value == pieceName)
                 {
-                    locationName = archipelago_Client.storagePlacementsArray[i, 0];
+                    locationName = storage.Key;
                 }
             }
         }

--- a/Shivers Randomizer/Archipelago_Client.xaml
+++ b/Shivers Randomizer/Archipelago_Client.xaml
@@ -4,9 +4,11 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:Shivers_Randomizer"
+      xmlns:properties="clr-namespace:Shivers_Randomizer.Properties"
       mc:Ignorable="d" 
       Height="537" Width="1000" Background="#FF333333" MinHeight="577" MinWidth="898"
-      Title="Archipelago Client">
+      Title="Archipelago Client"
+      DataContext="{x:Static properties:Settings.Default}">
     <Window.Resources>
         <Style x:Key="labelEnabled">
             <Style.Triggers>
@@ -34,9 +36,9 @@
 
         <Border Grid.Column="0" Grid.Row="0" BorderThickness="0.5" BorderBrush="Black" Grid.ColumnSpan="3"/>
         <Label Content="Server IP:Port" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Name="label1" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="75" Grid.Row="0" Grid.ColumnSpan="2"/>
-        <TextBox x:Name="serverIP" Text="archipelago.gg:" FontSize="16" Background="#FFF0F0F0" Height="24" Width="206" Margin="80,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Row="0" Grid.ColumnSpan="2"/>
+        <TextBox x:Name="serverIP" Text="{Binding serverIp, Mode=OneWay}" FontSize="16" Background="#FFF0F0F0" Height="24" Width="206" Margin="80,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Row="0" Grid.ColumnSpan="2"/>
         <Label Content="Slot:" FontSize="16" Foreground="White" Height="30" HorizontalAlignment="Left" Margin="296,0,0,0" Name="label3" VerticalAlignment="Center" VerticalContentAlignment="Center" Width="41"/>
-        <TextBox x:Name="slotName" Text="" FontSize="16" Background="#FFF0F0F0" Height="24" Width="145" Margin="341,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.ColumnSpan="3"/>
+        <TextBox x:Name="slotName" Text="{Binding slotName, Mode=OneWay}" FontSize="16" Background="#FFF0F0F0" Height="24" Width="145" Margin="341,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.ColumnSpan="3"/>
         <Label Content="Password:" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Margin="495,0,0,0" Name="label2" VerticalAlignment="Center" Grid.ColumnSpan="2" VerticalContentAlignment="Center"/>
         <TextBox x:Name="serverPassword" Text="" FontSize="16" Background="#FFF0F0F0" Height="24" Width="153" Margin="579,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.ColumnSpan="2"/>
         <Button x:Name="buttonConnect" Content="Connect" FontSize="16" Foreground="White" Background="#FF585858" Height="24" Width="92" HorizontalAlignment="Left" VerticalAlignment="Center" Click="ButtonConnect_Click" IsDefault="True" Padding="0,0" Grid.Column="0" Grid.Row="0" Margin="742,0,0,0" Grid.ColumnSpan="3"/>

--- a/Shivers Randomizer/Archipelago_Client.xaml
+++ b/Shivers Randomizer/Archipelago_Client.xaml
@@ -7,6 +7,18 @@
       mc:Ignorable="d" 
       Height="537" Width="1000" Background="#FF333333" MinHeight="577" MinWidth="898"
       Title="Archipelago Client">
+    <Window.Resources>
+        <Style x:Key="labelEnabled">
+            <Style.Triggers>
+                <Trigger Property="Label.IsEnabled" Value="True">
+                    <Setter Property="Label.Foreground" Value="White" />
+                </Trigger>
+                <Trigger Property="Label.IsEnabled" Value="False">
+                    <Setter Property="Label.Foreground" Value="Gray" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
@@ -27,7 +39,7 @@
         <TextBox x:Name="slotName" Text="" FontSize="16" Background="#FFF0F0F0" Height="24" Width="145" Margin="341,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.ColumnSpan="3"/>
         <Label Content="Password:" FontSize="16" Foreground="White" Height="38" HorizontalAlignment="Left" Margin="495,0,0,0" Name="label2" VerticalAlignment="Center" Grid.ColumnSpan="2" VerticalContentAlignment="Center"/>
         <TextBox x:Name="serverPassword" Text="" FontSize="16" Background="#FFF0F0F0" Height="24" Width="153" Margin="579,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.ColumnSpan="2"/>
-        <Button x:Name="buttonConnect" Content="Connect" FontSize="16" Foreground="White" Background="#FF585858" Height="24" Width="92" HorizontalAlignment="Left" VerticalAlignment="Center" Click="ButtonConnect_Click" Padding="0,0" Grid.Column="0" Grid.Row="0" Margin="742,0,0,0" Grid.ColumnSpan="3"/>
+        <Button x:Name="buttonConnect" Content="Connect" FontSize="16" Foreground="White" Background="#FF585858" Height="24" Width="92" HorizontalAlignment="Left" VerticalAlignment="Center" Click="ButtonConnect_Click" IsDefault="True" Padding="0,0" Grid.Column="0" Grid.Row="0" Margin="742,0,0,0" Grid.ColumnSpan="3"/>
 
         <RichTextBox x:Name="ServerMessageBox" Background="#FF333333" FontSize="16" Foreground="White" IsReadOnly="True" Margin="0,0,0,0" Block.LineHeight="1" VerticalScrollBarVisibility="Visible" ScrollViewer.ScrollChanged="ServerMessageBox_ScrollChanged" Grid.Row="1" MinWidth="21" IsUndoEnabled="False" UndoLimit="0"/>
 
@@ -84,27 +96,27 @@
 
         <Border Grid.Column="2" Grid.Row="1" BorderThickness="0.5" BorderBrush="Black" Grid.RowSpan="2"/>
         <Label x:Name="LabelKeys" Content="Keys:" FontSize="16" Foreground="#FFA0BE82" Height="31" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyBedroom" Content="Bedroom" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,20,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyBedroomElevator" Content="Bedroom Elevator" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,40,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyEgypt" Content="Egypt" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,60,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyFrontDoor" Content="Front Door" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,80,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyGenerator" Content="Generator" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,100,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyGreenhouse" Content="Greenhouse" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,120,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyJantiorCloset" Content="Janitor Closet" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,140,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyLibrary" Content="Library" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,160,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyOcean" Content="Ocean" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,180,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyOffice" Content="Office" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,200,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyOfficeElevator" Content="Office Elevator" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,220,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyPrehistoric" Content="Prehistoric" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,240,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyProjector" Content="Projector" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,260,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyPuzzle" Content="Puzzle" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,280,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyShaman" Content="Shaman" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyThreeFloorElevator" Content="Three Floor Elevator" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,320,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyTorture" Content="Torture" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,340,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyUFO" Content="UFO" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,360,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyUndergroundLake" Content="Underground Lake" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,380,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyWorkshop" Content="Workshop" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,400,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1"/>
-        <Label x:Name="LabelKeyCrawling" Content="Crawling" FontSize="16" Foreground="Gray" Height="32" HorizontalAlignment="Left" Margin="0,440,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" Width="79"/>
+        <Label x:Name="LabelKeyBedroom" Content="Bedroom" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,20,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyBedroomElevator" Content="Bedroom Elevator" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,40,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyEgypt" Content="Egypt" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,60,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyFrontDoor" Content="Front Door" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,80,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyGenerator" Content="Generator" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,100,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyGreenhouse" Content="Greenhouse" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,120,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyJantiorCloset" Content="Janitor Closet" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,140,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyLibrary" Content="Library" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,160,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyOcean" Content="Ocean" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,180,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyOffice" Content="Office" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,200,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyOfficeElevator" Content="Office Elevator" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,220,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyPrehistoric" Content="Prehistoric" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,240,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyProjector" Content="Projector" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,260,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyPuzzle" Content="Puzzle" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,280,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyShaman" Content="Shaman" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyThreeFloorElevator" Content="Three Floor Elevator" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,320,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyTorture" Content="Torture" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,340,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyUFO" Content="UFO" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,360,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyUndergroundLake" Content="Underground Lake" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,380,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyWorkshop" Content="Workshop" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,400,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" IsEnabled="False"/>
+        <Label x:Name="LabelKeyCrawling" Content="Crawling" FontSize="16" Style="{StaticResource labelEnabled}" Height="32" HorizontalAlignment="Left" Margin="0,440,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" Width="79" IsEnabled="False"/>
         <Label x:Name="LabelEasierLyre" Content="Easier Lyre x 0" FontSize="16" Foreground="White" Height="32" HorizontalAlignment="Left" Margin="0,480,0,0" VerticalAlignment="Top" Grid.Column="2" Grid.Row="1" Width="120" Visibility="Hidden" Grid.RowSpan="2"/>
 
     </Grid>

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -4,6 +4,7 @@ using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.Models;
 using Archipelago.MultiClient.Net.Packets;
 using Newtonsoft.Json.Linq;
+using Shivers_Randomizer.Properties;
 using Shivers_Randomizer.utils;
 using System;
 using System.Collections.Generic;
@@ -429,6 +430,8 @@ public partial class Archipelago_Client : Window
                 reconnectionAttempts = 0;
                 buttonConnect.Content = "Disconnect";
                 buttonConnect.IsDefault = false;
+                Settings.Default.serverIp = serverIP.Text;
+                Settings.Default.slotName = slotName.Text;
 
                 if (manualReconnect)
                 {

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -498,7 +498,7 @@ public partial class Archipelago_Client : Window
     {
         // Initilize Data storage
         session?.DataStorage[Scope.Slot, "PlayerLocation"].Initialize(1012);
-        session?.DataStorage[Scope.Slot, "LastRecievedItemValue"].Initialize(0);
+        session?.DataStorage[Scope.Slot, "NumItemsReceived"].Initialize(0);
         session?.DataStorage[Scope.Slot, "SkullDialPrehistoric"].Initialize(skullDialPrehistoric);
         session?.DataStorage[Scope.Slot, "SkullDialTarRiver"].Initialize(skullDialTarRiver);
         session?.DataStorage[Scope.Slot, "SkullDialWerewolf"].Initialize(skullDialWerewolf);
@@ -578,16 +578,16 @@ public partial class Archipelago_Client : Window
 
     public async void ReportNewItemsReceived()
     {
-        int lastItemCount = await LoadData("LastReceivedItemValue") ?? 0;
+        int numItemsReceived = await LoadData("NumItemsReceived") ?? 0;
         List<int> items = GetItemsFromArchipelagoServer();
         Brush plumBrush = new SolidColorBrush(System.Windows.Media.Color.FromRgb(175, 153, 239));
 
-        if (lastItemCount < items.Count)
+        if (numItemsReceived < items.Count)
         {
             ServerMessageBox.Dispatcher.Invoke(() =>
             {
                 ServerMessageBox.AppendTextWithColor($"Since you last connected you have received the following items:{Environment.NewLine}", Brushes.LimeGreen);
-                for (int i = lastItemCount; i < items.Count; i++)
+                for (int i = numItemsReceived; i < items.Count; i++)
                 {
                     string itemName = GetItemName(items[i]) ?? "Error Retrieving Item";
                     string message = $"{itemName} {Environment.NewLine}";
@@ -604,7 +604,7 @@ public partial class Archipelago_Client : Window
 
                 ScrollMessages();
             });
-            SaveData("LastReceivedItemValue", items.Count);
+            SaveData("NumItemsReceived", items.Count);
         }
     }
 

--- a/Shivers Randomizer/AttachPopup.xaml
+++ b/Shivers Randomizer/AttachPopup.xaml
@@ -86,7 +86,7 @@
             <Button x:Name="button_GetProcessList" Content="Get Processes" Click="Button_GetProcessList_Click"
                     HorizontalAlignment="Left" Margin="20,0,0,0" />
             <Button Grid.Column="1" x:Name="button_Attach" Content="Attach" Click="Button_Attach_Click"
-                    HorizontalAlignment="Right" Margin="0,0,20,0" IsEnabled="False" />
+                    HorizontalAlignment="Right" Margin="0,0,20,0" IsEnabled="False" IsDefault="True" />
         </Grid>
     </Grid>
 </Window>

--- a/Shivers Randomizer/LiveSplit.xaml
+++ b/Shivers Randomizer/LiveSplit.xaml
@@ -160,9 +160,9 @@
             </Grid.ColumnDefinitions>
 
             <Button x:Name="button_Cancel" Content="Cancel" Click="Button_Cancel_Click"
-                    HorizontalAlignment="Left" />
+                    IsCancel="True" HorizontalAlignment="Left" />
             <Button Grid.Column="1" x:Name="button_Connect" Content="Connect" Click="Button_Connect_Click"
-                    HorizontalAlignment="Right" />
+                    IsDefault="True" HorizontalAlignment="Right" />
         </Grid>
     </Grid>
 </Window>

--- a/Shivers Randomizer/MainWindow.xaml
+++ b/Shivers Randomizer/MainWindow.xaml
@@ -229,7 +229,7 @@
             </StackPanel>
 
             <StackPanel Margin="0,20,0,0">
-                <Button x:Name="button_Scramble" Content="Scramble" IsEnabled="False" HorizontalAlignment="Center" Click="Button_Scramble_Click"/>
+                <Button x:Name="button_Scramble" Content="Scramble" IsEnabled="False" HorizontalAlignment="Center" Click="Button_Scramble_Click" IsDefault="True"/>
                 <Label x:Name="label_ScrambleFeedback" Content="Scramble Number: 0" Margin="0,10,0,0" />
                 <Label x:Name="label_Seed" Content="Seed: " Margin="0,5,0,0" />
                 <Label x:Name="label_Flagset" Content="Flagset: " Margin="0,5,0,0" />

--- a/Shivers Randomizer/Message.xaml
+++ b/Shivers Randomizer/Message.xaml
@@ -72,6 +72,6 @@
         </Grid.RowDefinitions>
 
         <TextBlock x:Name="text_Message" Text="Message" Margin="20,20,20,0" HorizontalAlignment="Left" VerticalAlignment="Top" TextWrapping="Wrap" />
-        <Button Grid.Row="1" x:Name="button_OK" Content="OK" Margin="20,20,20,20" HorizontalAlignment="Right" VerticalAlignment="Center" Click="ButtonOK_Click" />
+        <Button Grid.Row="1" x:Name="button_OK" Content="OK" Margin="20,20,20,20" HorizontalAlignment="Right" VerticalAlignment="Center" Click="ButtonOK_Click" IsDefault="True" />
     </Grid>
 </Window>

--- a/Shivers Randomizer/Message.xaml.cs
+++ b/Shivers Randomizer/Message.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 
 namespace Shivers_Randomizer;
 

--- a/Shivers Randomizer/Properties/AssemblyInfo.cs
+++ b/Shivers Randomizer/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Shivers Randomizer")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Shivers Randomizer/Properties/AssemblyInfo.cs
+++ b/Shivers Randomizer/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Shivers Randomizer")]
-[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -49,6 +49,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.7")]
-[assembly: AssemblyFileVersion("2.6.7")]
-[assembly: AssemblyInformationalVersion("2.6.7")]
+[assembly: AssemblyVersion("2.6.8")]
+[assembly: AssemblyFileVersion("2.6.8")]
+[assembly: AssemblyInformationalVersion("2.6.8")]

--- a/Shivers Randomizer/Properties/Settings.Designer.cs
+++ b/Shivers Randomizer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Shivers_Randomizer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -20,6 +20,30 @@ namespace Shivers_Randomizer.Properties {
         public static Settings Default {
             get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("archipelago.gg:")]
+        public string serverIp {
+            get {
+                return ((string)(this["serverIp"]));
+            }
+            set {
+                this["serverIp"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string slotName {
+            get {
+                return ((string)(this["slotName"]));
+            }
+            set {
+                this["slotName"] = value;
             }
         }
     }

--- a/Shivers Randomizer/Properties/Settings.settings
+++ b/Shivers Randomizer/Properties/Settings.settings
@@ -1,7 +1,12 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="Shivers_Randomizer.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="serverIp" Type="System.String" Scope="User">
+      <Value Profile="(Default)">archipelago.gg:</Value>
+    </Setting>
+    <Setting Name="slotName" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/Shivers Randomizer/Shivers Randomizer.csproj
+++ b/Shivers Randomizer/Shivers Randomizer.csproj
@@ -44,7 +44,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="archipelago.multiclient.net" Version="5.0.6" />
+    <PackageReference Include="archipelago.multiclient.net" Version="6.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.8" />


### PR DESCRIPTION
- User settings for `serverIp` and `slotName`
- Enables default (Enter) button in various windows (Scramble in main, Attach in Attach popup, OK in Message dialogs, Connect in LiveSplit, Connect in AP which is not default when showing disconnect)
- Enables cancel (ESC) button in LiveSplit
- Missing option message box now uses shivers default message box
- Warnings cleaned up and Jtokens handled better
- AP key labels have style triggers on `IsEnabled`
- MultiClient package updated to latest
- Updates version