### PR TITLE
Prevents orphan process

### DIFF
--- a/Shivers Randomizer/App.xaml.cs
+++ b/Shivers Randomizer/App.xaml.cs
@@ -143,10 +143,9 @@ public partial class App : Application
         RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
     }
 
-    public void SafeShutdown()
+    public async Task SafeShutdown()
     {
-        archipelago_Client?.Close();
-        archipelago_Client = null;
+        await (archipelago_Client?.SafeShutdown() ?? Task.CompletedTask);
         liveSplit?.Disconnect();
         liveSplit?.Close();
         liveSplit = null;
@@ -1292,7 +1291,7 @@ public partial class App : Application
         }
         else if (archipelago_Client?.IsConnected == true)
         {
-            archipelago_Client?.Disconnect();
+            await (archipelago_Client?.DisconnectAsync() ?? Task.CompletedTask);
         }
         else
         {

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -71,21 +71,30 @@ public partial class Archipelago_Client : Window
         app.mainWindow.DisableOptions();
     }
 
-    protected override void OnClosed(EventArgs e)
+    public async Task SafeShutdown()
     {
-        base.OnClosed(e);
         messageTimer.Stop();
-        Disconnect();
+        await DisconnectAsync();
         serverUrl = null;
         userName = null;
         password = null;
         session = null;
         MainWindow.isArchipelagoClientOpen = false;
-        app.archipelago_Client = null;
         app.mainWindow.EnableOptions();
+        app.archipelago_Client = null;
+        Close();
     }
 
-    public LoginResult Connect(string server, string user, string pass, bool reconnect = false)
+    protected override async void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        if (app.archipelago_Client != null)
+        {
+            await SafeShutdown();
+        }
+    }
+
+    public async Task<LoginResult> ConnectAsync(string server, string user, string pass, bool reconnect = false)
     {
         if (IsConnected && cachedConnectionResult != null)
         {
@@ -94,7 +103,7 @@ public partial class Archipelago_Client : Window
                 return cachedConnectionResult;
             }
 
-            Disconnect();
+            await DisconnectAsync();
         }
 
         if (!reconnect)
@@ -148,9 +157,9 @@ public partial class Archipelago_Client : Window
                             "This client version can only be used for games generated with Archipelago <=0.5.0."
                         );
 
-                        message.Closed += (s, e) =>
+                        message.Closed += async (s, e) =>
                         {
-                            Disconnect();
+                            await DisconnectAsync();
                         };
                         message.ShowDialog();
                     }
@@ -266,9 +275,9 @@ public partial class Archipelago_Client : Window
         {
             if (IsConnected)
             {
-                Dispatcher.Invoke(() =>
+                Dispatcher.Invoke(async () =>
                 {
-                    Disconnect();
+                    await DisconnectAsync();
                 });
             }
 
@@ -286,7 +295,7 @@ public partial class Archipelago_Client : Window
         }
     }
 
-    private void ReconnectionTimer_Tick(object? sender, EventArgs e)
+    private async void ReconnectionTimer_Tick(object? sender, EventArgs e)
     {
         reconnectionTimer.Stop();
         if (!IsConnected && !userManuallyReconnected)
@@ -297,7 +306,7 @@ public partial class Archipelago_Client : Window
                 ServerMessageBox.AppendTextWithColor(messageToPrint, Brushes.Red);
                 ScrollMessages();
             });
-            AttemptConnection();
+            await AttemptConnection();
 
             if (!IsConnected)
             {
@@ -321,7 +330,7 @@ public partial class Archipelago_Client : Window
                     ServerMessageBox.Dispatcher.Invoke(() =>
                     {
                         string messageToPrint = $"Max reconnection attempts reached.{Environment.NewLine}";
-                        messageToPrint += $"Try refresing the room, check connection settings, or check internet.{Environment.NewLine}";
+                        messageToPrint += $"Try refreshing the room, check connection settings, or check internet.{Environment.NewLine}";
                         ServerMessageBox.AppendTextWithColor(messageToPrint, Brushes.Red);
                         ScrollMessages();
                     });
@@ -338,7 +347,7 @@ public partial class Archipelago_Client : Window
         }
     }
 
-    public async void Disconnect()
+    public async Task DisconnectAsync()
     {
         if (session != null)
         {
@@ -348,9 +357,12 @@ public partial class Archipelago_Client : Window
             }
 
             cachedConnectionResult = null;
-            buttonConnect.Content = "Connect";
-            buttonConnect.IsDefault = true;
             finishedConnecting = false;
+            Dispatcher.Invoke(() =>
+            {
+                buttonConnect.Content = "Connect";
+                buttonConnect.IsDefault = true;
+            });
 
             app.StopArchipelago();
         }
@@ -445,31 +457,31 @@ public partial class Archipelago_Client : Window
         }
     }
 
-    private void ButtonConnect_Click(object sender, RoutedEventArgs e)
+    private async void ButtonConnect_Click(object sender, RoutedEventArgs e)
     {
         if (!IsConnected)
         {
-            AttemptConnection(reconnectionAttempts > 0);
+            await AttemptConnection(reconnectionAttempts > 0);
         }
         else
         {
             userManuallyDisconnected = true;
-            Disconnect();
+            await DisconnectAsync();
         }
     }
 
-    private void AttemptConnection(bool manualReconnect = false)
+    private async Task AttemptConnection(bool manualReconnect = false)
     {
         using (new CursorBusy())
         {
             if (serverUrl == null || serverUrl == "localhost" && serverIP.Text != "localhost" ||
                 serverUrl.Split(":").LastOrDefault() != serverIP.Text.Split(":").LastOrDefault())
             {
-                Connect(serverIP.Text, slotName.Text, serverPassword.Text);
+                await ConnectAsync(serverIP.Text, slotName.Text, serverPassword.Text);
             }
             else
             {
-                Connect(serverUrl, slotName.Text, serverPassword.Text, manualReconnect);
+                await ConnectAsync(serverUrl, slotName.Text, serverPassword.Text, manualReconnect);
             }
 
             if (IsConnected)

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -437,11 +437,17 @@ public partial class Archipelago_Client : Window
             part.Color.G = 153;
             part.Color.B = 239;
         }
-        else if(part.Color == MessagePartColor.SlateBlue)
+        else if (part.Color == MessagePartColor.SlateBlue)
         {
             part.Color.R = 109;
             part.Color.G = 139;
             part.Color.B = 232;
+        }
+        else if (part.Color == MessagePartColor.Blue)
+        {
+            part.Color.R = 100;
+            part.Color.G = 149;
+            part.Color.B = 237;
         }
     }
 

--- a/Shivers Randomizer/MainWindow.xaml.cs
+++ b/Shivers Randomizer/MainWindow.xaml.cs
@@ -25,84 +25,90 @@ public partial class MainWindow : Window
         Title += $" v{version}";
     }
 
-    protected override void OnClosed(EventArgs e)
+    protected override async void OnClosed(EventArgs e)
     {
         base.OnClosed(e);
-        app.SafeShutdown();
+        await app.SafeShutdown();
     }
 
     public void EnableOptions()
     {
-        checkBoxVanilla.IsEnabled = true;
-        checkBoxSuperRandomizer.IsEnabled = true;
-        checkBoxIncludeAsh.IsEnabled = true;
-        checkBoxIncludeLightning.IsEnabled = true;
-        checkBoxEarlyBeth.IsEnabled = true;
-        checkBoxExtraLocations.IsEnabled = true;
-        checkBoxExcludeLyre.IsEnabled = false;
+        Dispatcher.Invoke(() =>
+        {
+            checkBoxVanilla.IsEnabled = true;
+            checkBoxSuperRandomizer.IsEnabled = true;
+            checkBoxIncludeAsh.IsEnabled = true;
+            checkBoxIncludeLightning.IsEnabled = true;
+            checkBoxEarlyBeth.IsEnabled = true;
+            checkBoxExtraLocations.IsEnabled = true;
+            checkBoxExcludeLyre.IsEnabled = false;
 
-        checkBoxSRRace.IsEnabled = true;
-        checkBoxRedDoor.IsEnabled = true;
-        checkBoxOnly4x4Elevators.IsEnabled = true;
-        checkBoxElevatorsStaySolved.IsEnabled = true;
-        checkBoxEarlyLightning.IsEnabled = false;
+            checkBoxSRRace.IsEnabled = true;
+            checkBoxRedDoor.IsEnabled = true;
+            checkBoxOnly4x4Elevators.IsEnabled = true;
+            checkBoxElevatorsStaySolved.IsEnabled = true;
+            checkBoxEarlyLightning.IsEnabled = false;
 
-        checkBoxRoomShuffle.IsEnabled = true;
-        checkBoxIncludeElevators.IsEnabled = false;
+            checkBoxRoomShuffle.IsEnabled = true;
+            checkBoxIncludeElevators.IsEnabled = false;
 
-        checkBoxSolvedLyre.IsEnabled = true;
-        checkBoxFullPots.IsEnabled = true;
-        checkBoxFirstToTheOnlyFive.IsEnabled = true;
-        checkBoxUnlockEntrance.IsEnabled = true;
+            checkBoxSolvedLyre.IsEnabled = true;
+            checkBoxFullPots.IsEnabled = true;
+            checkBoxFirstToTheOnlyFive.IsEnabled = true;
+            checkBoxUnlockEntrance.IsEnabled = true;
 
-        button_Scramble.IsEnabled = true;
+            button_Scramble.IsEnabled = true;
+        });
     }
 
     public void DisableOptions()
     {
-        checkBoxVanilla.IsEnabled = false;
-        checkBoxVanilla.IsChecked = false;
-        checkBoxSuperRandomizer.IsEnabled = false;
-        checkBoxSuperRandomizer.IsChecked = false;
-        checkBoxIncludeAsh.IsEnabled = false;
-        checkBoxIncludeAsh.IsChecked = false;
-        checkBoxIncludeLightning.IsEnabled = false;
-        checkBoxIncludeLightning.IsChecked = false;
-        checkBoxEarlyBeth.IsEnabled = false;
-        checkBoxEarlyBeth.IsChecked = false;
-        checkBoxExtraLocations.IsEnabled = false;
-        checkBoxExtraLocations.IsChecked = false;
-        checkBoxExcludeLyre.IsEnabled = false;
-        checkBoxExcludeLyre.IsChecked = false;
+        Dispatcher.Invoke(() =>
+        {
+            checkBoxVanilla.IsEnabled = false;
+            checkBoxVanilla.IsChecked = false;
+            checkBoxSuperRandomizer.IsEnabled = false;
+            checkBoxSuperRandomizer.IsChecked = false;
+            checkBoxIncludeAsh.IsEnabled = false;
+            checkBoxIncludeAsh.IsChecked = false;
+            checkBoxIncludeLightning.IsEnabled = false;
+            checkBoxIncludeLightning.IsChecked = false;
+            checkBoxEarlyBeth.IsEnabled = false;
+            checkBoxEarlyBeth.IsChecked = false;
+            checkBoxExtraLocations.IsEnabled = false;
+            checkBoxExtraLocations.IsChecked = false;
+            checkBoxExcludeLyre.IsEnabled = false;
+            checkBoxExcludeLyre.IsChecked = false;
 
-        checkBoxSRRace.IsEnabled = false;
-        checkBoxSRRace.IsChecked = false;
-        checkBoxRedDoor.IsEnabled = false;
-        checkBoxRedDoor.IsChecked = false;
-        checkBoxOnly4x4Elevators.IsEnabled = false;
-        checkBoxOnly4x4Elevators.IsChecked = false;
-        checkBoxElevatorsStaySolved.IsEnabled = false;
-        checkBoxElevatorsStaySolved.IsChecked = false;
-        checkBoxEarlyLightning.IsEnabled = false;
-        checkBoxEarlyLightning.IsChecked = false;
+            checkBoxSRRace.IsEnabled = false;
+            checkBoxSRRace.IsChecked = false;
+            checkBoxRedDoor.IsEnabled = false;
+            checkBoxRedDoor.IsChecked = false;
+            checkBoxOnly4x4Elevators.IsEnabled = false;
+            checkBoxOnly4x4Elevators.IsChecked = false;
+            checkBoxElevatorsStaySolved.IsEnabled = false;
+            checkBoxElevatorsStaySolved.IsChecked = false;
+            checkBoxEarlyLightning.IsEnabled = false;
+            checkBoxEarlyLightning.IsChecked = false;
 
-        checkBoxRoomShuffle.IsEnabled = false;
-        checkBoxRoomShuffle.IsChecked = false;
-        checkBoxIncludeElevators.IsEnabled = false;
-        checkBoxIncludeElevators.IsChecked = false;
+            checkBoxRoomShuffle.IsEnabled = false;
+            checkBoxRoomShuffle.IsChecked = false;
+            checkBoxIncludeElevators.IsEnabled = false;
+            checkBoxIncludeElevators.IsChecked = false;
 
-        checkBoxSolvedLyre.IsEnabled = false;
-        checkBoxSolvedLyre.IsChecked = false;
-        checkBoxFullPots.IsEnabled = false;
-        checkBoxFullPots.IsChecked = false;
-        checkBoxFirstToTheOnlyFive.IsEnabled = false;
-        checkBoxFirstToTheOnlyFive.IsChecked = false;
-        checkBoxUnlockEntrance.IsEnabled = false;
-        checkBoxUnlockEntrance.IsChecked = false;
-        checkBoxAnywhereLightning.IsEnabled = false;
-        checkBoxAnywhereLightning.IsChecked = false;
+            checkBoxSolvedLyre.IsEnabled = false;
+            checkBoxSolvedLyre.IsChecked = false;
+            checkBoxFullPots.IsEnabled = false;
+            checkBoxFullPots.IsChecked = false;
+            checkBoxFirstToTheOnlyFive.IsEnabled = false;
+            checkBoxFirstToTheOnlyFive.IsChecked = false;
+            checkBoxUnlockEntrance.IsEnabled = false;
+            checkBoxUnlockEntrance.IsChecked = false;
+            checkBoxAnywhereLightning.IsEnabled = false;
+            checkBoxAnywhereLightning.IsChecked = false;
 
-        button_Scramble.IsEnabled = false;
+            button_Scramble.IsEnabled = false;
+        });
     }
 
     //Display popup for attaching to shivers process

--- a/Shivers Randomizer/Properties/AssemblyInfo.cs
+++ b/Shivers Randomizer/Properties/AssemblyInfo.cs
@@ -49,6 +49,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.14")]
-[assembly: AssemblyFileVersion("2.6.14")]
-[assembly: AssemblyInformationalVersion("2.6.14")]
+[assembly: AssemblyVersion("2.6.15")]
+[assembly: AssemblyFileVersion("2.6.15")]
+[assembly: AssemblyInformationalVersion("2.6.15")]


### PR DESCRIPTION
When closing the main app window, while AP client is connected, this change now makes sure the AP client closes before the app shuts down.

This prevents the orphan process from running in the background.