### PR TITLE
History feature of AP client

### DIFF
--- a/Shivers Randomizer/Archipelago_Client.xaml
+++ b/Shivers Randomizer/Archipelago_Client.xaml
@@ -47,7 +47,7 @@
         <RichTextBox x:Name="ServerMessageBox" Background="#FF333333" FontSize="16" Foreground="White" IsReadOnly="True" Margin="0,0,0,0" Block.LineHeight="1" VerticalScrollBarVisibility="Visible" ScrollViewer.ScrollChanged="ServerMessageBox_ScrollChanged" Grid.Row="1" MinWidth="21" IsUndoEnabled="False" UndoLimit="0"/>
 
         <Button x:Name="buttonCommands" Content="Command:" FontSize="16" Foreground="White" Height="28" Width="100" HorizontalAlignment="Left" VerticalAlignment="Center" VerticalContentAlignment="Center" Background="#FF585858" Grid.Row="2" Click="ButtonCommands_Click"/>
-        <TextBox x:Name="commandBox" FontSize="16" Background="#FFF0F0F0" VerticalContentAlignment="Center" Height="30" Margin="100,0,0,0" TextWrapping="Wrap" VerticalAlignment="Center" Grid.Row="2" KeyDown="CommandBox_KeyDown"/>
+        <TextBox x:Name="commandBox" FontSize="16" Background="#FFF0F0F0" VerticalContentAlignment="Center" Height="30" Margin="100,0,0,0" TextWrapping="Wrap" VerticalAlignment="Center" Grid.Row="2" PreviewKeyDown="CommandBox_KeyDown"/>
 
         <Border Grid.Column="1" Grid.Row="1" BorderThickness="0.5" BorderBrush="Black" Grid.RowSpan="2"/>
         <Label Content="Desk Drawer: " FontSize="16" Foreground="#FFA0BE82" Height="31" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"/>

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -44,7 +44,7 @@ public partial class Archipelago_Client : Window
     public CollectBehavior slotDataCollectBehavior;
     public int slotDataIxupiCapturesNeeded = 10;
     public ArchipelagoDataStorage? dataStorage;
-    private List<string> commandBuffer = new();
+    private List<string> commandBuffer = new List<string> {""};
     private int commandPointer = 0;
     private bool userHasScrolledUp;
     private bool userManuallyReconnected;

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -44,6 +44,8 @@ public partial class Archipelago_Client : Window
     public CollectBehavior slotDataCollectBehavior;
     public int slotDataIxupiCapturesNeeded = 10;
     public ArchipelagoDataStorage? dataStorage;
+    private List<string> commandBuffer = new();
+    private int commandPointer = 0;
     private bool userHasScrolledUp;
     private bool userManuallyReconnected;
     private bool userManuallyDisconnected;
@@ -758,9 +760,19 @@ public partial class Archipelago_Client : Window
         userHasScrolledUp = e.VerticalOffset < e.ExtentHeight - e.ViewportHeight;
     }
 
+    private void InsertToCommandBuffer(string CommandMessage)
+    {
+        if (CommandMessage != "")
+        {
+            commandBuffer.Insert(0, CommandMessage);
+        }
+    }
+
     private void ButtonCommands_Click(object sender, RoutedEventArgs e)
     {
+        commandPointer = 0;
         string CommandMessage = commandBox.Text;
+        InsertToCommandBuffer(CommandMessage);
         commandBox.Text = "";
         Commands(CommandMessage);
     }
@@ -768,9 +780,27 @@ public partial class Archipelago_Client : Window
     {
         if (e.Key == Key.Enter)
         {
+            commandPointer = 0;
             string CommandMessage = commandBox.Text;
+            InsertToCommandBuffer(CommandMessage);
             commandBox.Text = "";
             Commands(CommandMessage);
+        }
+        else if (e.Key == Key.Up)
+        {
+            if (commandPointer != commandBuffer.Count)
+            {
+                commandPointer ++;
+            }
+            commandBox.Text = commandBuffer[commandPointer - 1];
+        }
+        else if (e.Key == Key.Down)
+        {
+            if (commandPointer > 0)
+            {
+                commandPointer -- ;
+            }
+            commandBox.Text = commandBuffer[commandPointer];
         }
     }
 

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -788,11 +788,11 @@ public partial class Archipelago_Client : Window
         }
         else if (e.Key == Key.Up)
         {
-            if (commandPointer != commandBuffer.Count)
+            if (commandPointer < commandBuffer.Count - 1)
             {
                 commandPointer ++;
             }
-            commandBox.Text = commandBuffer[commandPointer - 1];
+            commandBox.Text = commandBuffer[commandPointer];
         }
         else if (e.Key == Key.Down)
         {

--- a/Shivers Randomizer/Archipelago_Client.xaml.cs
+++ b/Shivers Randomizer/Archipelago_Client.xaml.cs
@@ -762,15 +762,22 @@ public partial class Archipelago_Client : Window
 
     private void InsertToCommandBuffer(string CommandMessage)
     {
-        if (CommandMessage != "")
+        if (!string.IsNullOrEmpty(CommandMessage))
         {
+            // Insert newest command at the front
             commandBuffer.Insert(0, CommandMessage);
+
+            // Remove oldest command if buffer exceeds max size
+            if (commandBuffer.Count > 10)
+            {
+                commandBuffer.RemoveAt(commandBuffer.Count - 1); // remove last (oldest)
+            }
         }
     }
 
     private void ButtonCommands_Click(object sender, RoutedEventArgs e)
     {
-        commandPointer = 0;
+        commandPointer = -1;
         string CommandMessage = commandBox.Text;
         InsertToCommandBuffer(CommandMessage);
         commandBox.Text = "";
@@ -780,11 +787,13 @@ public partial class Archipelago_Client : Window
     {
         if (e.Key == Key.Enter)
         {
-            commandPointer = 0;
+            commandPointer = -1;
             string CommandMessage = commandBox.Text;
             InsertToCommandBuffer(CommandMessage);
             commandBox.Text = "";
             Commands(CommandMessage);
+
+            e.Handled = true;
         }
         else if (e.Key == Key.Up)
         {
@@ -798,9 +807,14 @@ public partial class Archipelago_Client : Window
         {
             if (commandPointer > 0)
             {
-                commandPointer -- ;
+                commandPointer--;
+                commandBox.Text = commandBuffer[commandPointer];
             }
-            commandBox.Text = commandBuffer[commandPointer];
+            else if(commandPointer <= 0)
+            {
+                commandPointer = -1;
+                commandBox.Text = "";
+            }
         }
     }
 


### PR DESCRIPTION
When you typo a hint in the console you usually have to type everything again. This feature gives access to the history of entered commands with the up and down arrows.

Changes:

in `Shivers Randomizer/Archipelago_Client.xaml`
The `KeyDown` event is no longer set to `CommandBox_KeyDown`, instead that is passed on to `PreviewKeyDown`.
Reason:
While the TextBox doesn't have a default internal use for pressing "Enter", it does have one for using the arrow-keys. That action is used and swallowed whole, never reaching the `KeyDown` event. So simply setting `else if` cases for `Key.Up` and `Key.Down` in `Shivers Randomizer/Archipelago_Client.xaml.cs` is NOT sufficient.

`PreviewKeyDown` takes the input from the other direction of priority, so we get to control what it does _before_ the TextBox gets to use its internal control.

Alternatively, we could set `e.Handled = true` at the end of each case to make sure the TextBox never sees that input. But I don't see a reason for that.

Disclaimer: I used Gemini to identify this bug by giving it a minimal, anonymized code example. The code was not generated by AI.

in `Shivers Randomizer/Archipelago_Client.xaml.cs`
I create a buffer as a list of strings (initialized with the empty string as the only element) and a pointer initialized to 0.
Whenever a non-empty string message is sent via enter or clicking the button, it's inserted at position 0, as that makes the math easier.
then, hitting Up and Down increases or decreases the pointer unless it runs off limits. The current pointer read is then pasted into the command box.